### PR TITLE
Fix warnings in error reporter

### DIFF
--- a/assets/usefulstuff/shapes/item/tool/climbingpick.json
+++ b/assets/usefulstuff/shapes/item/tool/climbingpick.json
@@ -8,9 +8,9 @@
 	"textureSizes": {
 	},
 	"textures": {
-		"string": "item/tool/material/string",
-		"metal": "block/metal/ingot/copper",
-		"handle": "item/tool/material/handle"
+		"string": "game:item/tool/material/string",
+		"metal": "game:block/metal/ingot/copper",
+		"handle": "game:item/tool/material/handle"
 	},
 	"elements": [
 		{

--- a/assets/usefulstuff/shapes/item/tool/glider.json
+++ b/assets/usefulstuff/shapes/item/tool/glider.json
@@ -8,8 +8,8 @@
 	"textureSizes": {
 	},
 	"textures": {
-		"fabric": "block/cloth/linen/diamond1",
-		"wood": "block/wood/planks/generic"
+		"fabric": "game:block/cloth/linen/diamond1",
+		"wood": "game:block/wood/planks/generic"
 	},
 	"elements": [
 		{


### PR DESCRIPTION
```
18.10.2021 07:22:15 [Warning] Texture asset 'usefulstuff:textures/item/tool/material/string.png' not found (defined in Shape file usefulstuff:item/tool/climbingpick).
18.10.2021 07:22:15 [Warning] Texture asset 'usefulstuff:textures/block/metal/ingot/copper.png' not found (defined in Shape file usefulstuff:item/tool/climbingpick).
18.10.2021 07:22:15 [Warning] Texture asset 'usefulstuff:textures/item/tool/material/handle.png' not found (defined in Shape file usefulstuff:item/tool/climbingpick).

18.10.2021 07:22:15 [Warning] Texture asset 'usefulstuff:textures/block/cloth/linen/diamond1.png' not found (defined in Shape file usefulstuff:item/tool/glider).
18.10.2021 07:22:15 [Warning] Texture asset 'usefulstuff:textures/block/wood/planks/generic.png' not found (defined in Shape file usefulstuff:item/tool/glider).
```